### PR TITLE
Fix codeQL error

### DIFF
--- a/server/setup-database.js
+++ b/server/setup-database.js
@@ -6,6 +6,7 @@ const path = require("path");
 const Database = require("./database");
 const { allowDevAllOrigin } = require("./util-server");
 const mysql = require("mysql2/promise");
+const { tmpdir } = require("node:os");
 
 /**
  *  A standalone express app that is used to setup a database
@@ -215,7 +216,7 @@ class SetupDatabase {
                     if (dbConfig.caFile) {
                         const base64Data = dbConfig.caFile.replace(/^data:application\/octet-stream;base64,/, "");
                         const binaryData = Buffer.from(base64Data, "base64").toString("binary");
-                        const tempCaDirectory = fs.mkdtempSync("kuma-ca-");
+                        const tempCaDirectory = fs.mkdtempSync(path.join(tmpdir(), "kuma-ca-"));
                         dbConfig.caFilePath = path.resolve(tempCaDirectory, "ca.pem");
                         try {
                             fs.writeFileSync(dbConfig.caFilePath, binaryData, "binary");


### PR DESCRIPTION
------
Call "tmpdir()" a single time inside "database.js" and remove "caFilePath" from the config if the path starts with the temporary directory path as a failsafe

Fix whitespace

Move the unassignment of " dbConfig.ssl" and " dbConfig.ssl" outside the block responsible to move the CA file from the temporary directory to the data directory

Fix inverted "if" condition. Also add "path.resolve" to a path check in order to make sure that we are comparing absolute paths with each others

Remove unnecessary check for a ".pem" file, simplify the path check and fix the file copying to itself

Add additional path checks to avoid filename exploits

Fix issue where the temp directory used to temporarily store the CA file is within the working directory instead of the OS provided temp directory path
